### PR TITLE
[PPI-1511] add new methods for download classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,82 @@
-# CHANGELOG
+### Changelog
 
-* [1.0.0](#0.0.1)
+All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
-## 1.0.0
+#### [1.7.0](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/compare/1.6.0...1.7.0)
 
-* release of the stable package
+- Project guidelines update [`#29`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/29)
+- Updated CONTRIBUTION.md file, added CODE_OF_CONDUCT.md [`3c3f579`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/commit/3c3f5796b9c4ab01371f2140a3d07e3714d83dc5)
+- [PPI-1511] add new methods for download classes [`#30`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/30)
 
+#### [1.6.0](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/compare/1.5.0...1.6.0)
+
+> 26 March 2025
+
+- Bump @piwikpro/react-piwik-pro version [`#27`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/27)
+- Check documentation in on-push workflow [`#28`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/28)
+- Changed on-push workflow to build example app [`#26`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/26)
+
+#### [1.5.0](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/compare/1.4.1...1.5.0)
+
+> 26 February 2025
+
+- currency conversion [`#25`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/25)
+- Set provider upon initialization [`#24`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/24)
+
+#### [1.4.1](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/compare/1.4.0...1.4.1)
+
+> 16 January 2025
+
+- Fix initialization issue [`#23`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/23)
+
+#### [1.4.0](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/compare/1.3.0...1.4.0)
+
+> 13 January 2025
+
+- Update tracking-base-library, bump version [`#22`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/22)
+
+#### [1.3.0](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/compare/1.2.0...1.3.0)
+
+> 11 June 2024
+
+- Release 1.3.0 [`#19`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/19)
+
+#### [1.2.0](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/compare/1.1.1...1.2.0)
+
+> 9 May 2024
+
+- 1.2.0 Bump react-piwik-pro [`#18`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/18)
+
+#### [1.1.1](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/compare/1.1.0...1.1.1)
+
+> 25 March 2024
+
+- Bump follow-redirects from 1.15.3 to 1.15.6 in /example [`#13`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/13)
+- Bump follow-redirects from 1.15.5 to 1.15.6 in /plugin [`#14`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/14)
+- [PPI-1075] adding readme file to build [`#15`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/15)
+- [PPI-1075] fix run commend prepack in github action [`eebbc1d`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/commit/eebbc1ddb9373ae6eb20b9bf50fcf3b931eec80d)
+
+#### [1.1.0](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/compare/1.0.0...1.1.0)
+
+> 9 February 2024
+
+- Bump msgpackr from 1.9.9 to 1.10.1 in /plugin [`#12`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/12)
+- Bump follow-redirects from 1.15.3 to 1.15.5 in /plugin [`#11`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/11)
+- Bump msgpackr from 1.9.9 to 1.10.1 in /example [`#7`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/7)
+- PPI-979 new ecommerce methods for gatsby plugin [`#10`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/10)
+- [PPI-979] move the source code of plugin to a separate directory 'plugin' [`3c81081`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/commit/3c81081a78f9842a8da11a2f1ae3a33253456cf1)
+- [PPI-979] add support for new ecommerce methods [`8ae1a5f`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/commit/8ae1a5f1a2d5c56d645fad2be16d2525968517ed)
+- [PPI-979] update readme.md [`b08b488`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/commit/b08b488693ab0a6b14fc486ed14e0e8371d5f82b)
+
+#### 1.0.0
+
+> 24 November 2023
+
+- [PPI-940]: Update github action config - main.yml [`#5`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/5)
+- [SEC-728]: pin all gh action to a specific commit [`#4`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/4)
+- [SEC-728]: keep artifacts only one day [`#3`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/3)
+- [PPI-304]: prepare for first release [`#2`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/2)
+- Gatsby piwik pro plugin structure with example initial commit [`#1`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/pull/1)
+- feat: lib structure and example [`5ad205c`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/commit/5ad205c337cabc10d41f709b9b7c9379b192035f)
+- [PPI-304]: add content of contribution.md file [`9517f2d`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/commit/9517f2d2d8e50cb4d4a67e65af58e5a4255d20a7)
+- Initial commit [`13904ce`](https://github.com/PiwikPRO/gatsby-plugin-piwik-pro/commit/13904ce83e30464267a763e636581a4811f7c70c)

--- a/README.md
+++ b/README.md
@@ -1006,9 +1006,12 @@ ___
 ### Table of contents
 
 
+- [addDownloadClasses](#adddownloadclasses)
 - [addDownloadExtensions](#adddownloadextensions)
 - [enableLinkTracking](#enablelinktracking)
+- [getDownloadClasses](#getdownloadclasses)
 - [getLinkTrackingTimer](#getlinktrackingtimer)
+- [removeDownloadClasses](#removedownloadclasses)
 - [removeDownloadExtensions](#removedownloadextensions)
 - [setDownloadClasses](#setdownloadclasses)
 - [setDownloadExtensions](#setdownloadextensions)
@@ -1017,6 +1020,24 @@ ___
 - [setLinkTrackingTimer](#setlinktrackingtimer)
 - [trackLink](#tracklink)
 
+
+#### addDownloadClasses
+
+▸ **addDownloadClasses**(`classes`): `void`
+
+Adds new classes to the download classes list
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `classes` | `string`[] |
+
+##### Returns
+
+`void`
+
+___
 
 #### addDownloadExtensions
 
@@ -1057,6 +1078,18 @@ to a downloadable file creates a download event
 
 ___
 
+#### getDownloadClasses
+
+▸ **getDownloadClasses**(): `Promise`\<`string`[]\>
+
+Returns list of download classes (CSS classes that indicate a link is a download)
+
+##### Returns
+
+`Promise`\<`string`[]\>
+
+___
+
 #### getLinkTrackingTimer
 
 ▸ **getLinkTrackingTimer**(): `Promise`\<`number`\>
@@ -1066,6 +1099,24 @@ Returns lock/wait time after a request set by setLinkTrackingTimer
 ##### Returns
 
 `Promise`\<`number`\>
+
+___
+
+#### removeDownloadClasses
+
+▸ **removeDownloadClasses**(`classes`): `void`
+
+Removes classes from the download classes list
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `classes` | `string`[] |
+
+##### Returns
+
+`void`
 
 ___
 

--- a/example/src/pages/DownloadAndOutlink.tsx
+++ b/example/src/pages/DownloadAndOutlink.tsx
@@ -26,9 +26,24 @@ const pageData = {
       desc: 'Sets a list of class names that indicate whether a link is an outlink and not download.',
     },
     {
+      method: 'getDownloadClasses',
+      usage: 'DownloadAndOutlink.getDownloadClasses()',
+      desc: 'Returns a list of class names that indicate whether a list is a download and not an outlink.',
+    },
+    {
       method: 'setDownloadClasses',
       usage: 'DownloadAndOutlink.setDownloadClasses(classes: string[])',
       desc: 'Sets a list of class names that indicate whether a list is a download and not an outlink.',
+    },
+    {
+      method: 'addDownloadClasses',
+      usage: 'DownloadAndOutlink.addDownloadClasses(classes: string[])',
+      desc: 'Adds new classes to the download classes list.',
+    },
+    {
+      method: 'removeDownloadClasses',
+      usage: 'DownloadAndOutlink.removeDownloadClasses(classes: string[])',
+      desc: 'Removes classes from the download classes list.',
     },
     {
       method: 'setDownloadExtensions',
@@ -118,6 +133,20 @@ const DownloadAndOutlinkPage = () => {
         </button>
         <button
           onClick={() => {
+            DownloadAndOutlink.addDownloadClasses(['this-is-a-download'])
+          }}
+        >
+          DownloadAndOutlink.addDownloadClasses
+        </button>
+        <button
+          onClick={() => {
+            DownloadAndOutlink.removeDownloadClasses(['this-is-a-download'])
+          }}
+        >
+          DownloadAndOutlink.removeDownloadClasses
+        </button>
+        <button
+          onClick={() => {
             DownloadAndOutlink.addDownloadExtensions(['rar'])
           }}
         >
@@ -179,6 +208,11 @@ const DownloadAndOutlinkPage = () => {
           Download XLXS
         </a>{' '}
         - download turned off by default using className
+        <br />
+        <a className="this-is-a-download" href={`example.xlsx`} download>
+          Download XLXS
+        </a>{' '}
+        - download or outlink depending on if the class <code>this-is-a-download</code> is in the list of download classes
       </div>
       <p>
         <code>DownloadAndOutlink.getLinkTrackingTimer()</code> -{' '}

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1949,17 +1949,17 @@
   version "0.0.0"
   uid ""
 
-"@piwikpro/react-piwik-pro@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@piwikpro/react-piwik-pro/-/react-piwik-pro-2.4.0.tgz#46f707ec86d3a414926b40c3846a033debe57023"
-  integrity sha512-JTWcE5/BYCiSfKAtpFDsFyxe3zFrv9Atni7qg1j9q8CZ9WhYsx+ACcpyQRkpfYp8c+YQ47hX3LgqXU9FcmXBMw==
+"@piwikpro/react-piwik-pro@^2.5.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@piwikpro/react-piwik-pro/-/react-piwik-pro-2.6.0.tgz#8932072141ae8344af08f8d5e1672628a9adbbfe"
+  integrity sha512-yOF9pI24vL7yj2Fng7wJcU9nGEVLSwzEl41xThvLefkJmBriv7mSScJ/I1SA6nx0JkuW9T2NLFHlUKv500Lwyg==
   dependencies:
-    "@piwikpro/tracking-base-library" "^1.5.0"
+    "@piwikpro/tracking-base-library" "^1.7.0"
 
-"@piwikpro/tracking-base-library@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@piwikpro/tracking-base-library/-/tracking-base-library-1.5.0.tgz#9672fd743e7f8be3e2e8a89b65b30867a7488d83"
-  integrity sha512-PT6LHUL7SH4hzO3VliBFoLFqFC4vikSC6R9pbIcEH5fPmYC5W11x1ztRo6qpZ+BuFa/EEvunAdBdeDWMTkApPw==
+"@piwikpro/tracking-base-library@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@piwikpro/tracking-base-library/-/tracking-base-library-1.7.0.tgz#322f1f958ee9bd7a7e637d53c5458ad134ee3fb0"
+  integrity sha512-0u5YTcYO2As9T6ZFuJn0da6VYWz0sVYFFujkwiD8fz0o+Jjvl8r8Fk7rM2/ifLs03bqBOYe8MZRCjDKHWQzaiQ==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.10":
   version "0.5.11"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piwikpro/gatsby-plugin-piwik-pro",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Piwik PRO tracking library for Gatsby",
   "license": "MIT",
   "main": "index.js",
@@ -27,7 +27,7 @@
     "gatsby": "^5.0.0"
   },
   "dependencies": {
-    "@piwikpro/react-piwik-pro": "^2.5.0"
+    "@piwikpro/react-piwik-pro": "^2.6.0"
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",

--- a/plugin/src/version.ts
+++ b/plugin/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.6.0"
+export const VERSION = "1.7.0"

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -2165,17 +2165,17 @@
     chrome-trace-event "^1.0.2"
     nullthrows "^1.1.1"
 
-"@piwikpro/react-piwik-pro@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@piwikpro/react-piwik-pro/-/react-piwik-pro-2.5.0.tgz#dfd143ea5296027f3cbfc0e781087cadf691336e"
-  integrity sha512-g+Jep6pFq5QvhIOOicELVK5oMqsXH6g4F6xt6CXfoKymq21DFivz0ADNZdsbUsd/ZrtUQFib0Efk9DKo5Q8udA==
+"@piwikpro/react-piwik-pro@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@piwikpro/react-piwik-pro/-/react-piwik-pro-2.6.0.tgz#8932072141ae8344af08f8d5e1672628a9adbbfe"
+  integrity sha512-yOF9pI24vL7yj2Fng7wJcU9nGEVLSwzEl41xThvLefkJmBriv7mSScJ/I1SA6nx0JkuW9T2NLFHlUKv500Lwyg==
   dependencies:
-    "@piwikpro/tracking-base-library" "^1.6.0"
+    "@piwikpro/tracking-base-library" "^1.7.0"
 
-"@piwikpro/tracking-base-library@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@piwikpro/tracking-base-library/-/tracking-base-library-1.6.0.tgz#c08ac7331c514e9c2610669720cac9f99bad6a9b"
-  integrity sha512-jd88qqxGAtjSfdDLPuFzrk1hjnIQKCdSFynm3GE/fHB0drPsXZ/o1oXPY9YpAVX2dIkurrycRAzEhtC6KwSlfw==
+"@piwikpro/tracking-base-library@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@piwikpro/tracking-base-library/-/tracking-base-library-1.7.0.tgz#322f1f958ee9bd7a7e637d53c5458ad134ee3fb0"
+  integrity sha512-0u5YTcYO2As9T6ZFuJn0da6VYWz0sVYFFujkwiD8fz0o+Jjvl8r8Fk7rM2/ifLs03bqBOYe8MZRCjDKHWQzaiQ==
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.10":
   version "0.5.11"


### PR DESCRIPTION
Bumps tracking-base-library and this package's version to prepare for new release

**Note: this PR bumps gatsby-plugin-piwik-pro to 1.6.0**